### PR TITLE
Fix: improve feed detection

### DIFF
--- a/views/partials/feeds.hbs
+++ b/views/partials/feeds.hbs
@@ -1,4 +1,4 @@
 <div class="comp-feeds">
-<p>Get your feeds! Lovely and hot! In <a href="{{#if childrenType}}/{{childrenType}}{{/if}}/json">JSON</a>, <a href="{{#if childrenType}}/{{childrenType}}{{/if}}/rss">RSS</a>, and <a href="{{#if storage}}/{{storage}}{{/if}}/atom">Atom</a> formats!</p>
+<p>Get your feeds! Lovely and hot! In <a rel="alternate" type="application/json" href="{{#if childrenType}}/{{childrenType}}{{/if}}/json">JSON</a>, <a rel="alternate" type="application/rss+xml" href="{{#if childrenType}}/{{childrenType}}{{/if}}/rss">RSS</a>, and <a rel="alternate" type="application/atom+xml" href="{{#if storage}}/{{storage}}{{/if}}/atom">Atom</a> formats!</p>
 </div>
 


### PR DESCRIPTION
Add "rel" and "type" attributes to feed links; this improves the ability
for user agents such as browsers, addons, and fancy feedreaders to
detect feeds on a webpage.